### PR TITLE
Relax Python version requirements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,19 +23,16 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3
-
-      - name: Install system dependencies
-        run: sudo apt install libopenblas-dev
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
 
       - name: Install PDM
         run: python -m pip install pdm
@@ -45,6 +42,9 @@ jobs:
 
       - name: Lint
         run: pdm run pre-commit run --all-files
+
+      - name: Type check
+        run: pdm run pyright
 
       - name: Test
         env:

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform"]
 lock_version = "4.4"
-content_hash = "sha256:091b22fdd458340b0f0fbd19ad934743ed69ade56ada454e6e7670fb6fc94d4d"
+content_hash = "sha256:ed71e512e83ffb0797b84884ab6b83deed5ef838242bc7654aa16b8ba4716687"
 
 [[package]]
 name = "absl-py"
@@ -3216,6 +3216,16 @@ dependencies = [
 files = [
     {file = "syrupy-4.6.0-py3-none-any.whl", hash = "sha256:747aae1bcf3cb3249e33b1e6d81097874d23615982d5686ebe637875b0775a1b"},
     {file = "syrupy-4.6.0.tar.gz", hash = "sha256:231b1f5d00f1f85048ba81676c79448076189c4aef4d33f21ae32f3b4c565a54"},
+]
+
+[[package]]
+name = "termcolor"
+version = "2.4.0"
+requires_python = ">=3.8"
+summary = "ANSI color formatting for output in terminal"
+files = [
+    {file = "termcolor-2.4.0-py3-none-any.whl", hash = "sha256:9297c0df9c99445c2412e832e882a7884038a25617c60cea2ad69488d4040d63"},
+    {file = "termcolor-2.4.0.tar.gz", hash = "sha256:aab9e56047c8ac41ed798fa36d892a37aca6b3e9159f3e0c24bc64a9b3ac7b7a"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "scikit-learn>=1.3.2",
     "evaluate>=0.4.1",
     "rouge-score>=0.1.2",
+    "termcolor>=2.4.0",
 ]
 
 [tool.black]


### PR DESCRIPTION
We previously required `python <3.11` but are relaxing it to allow `python <4`

Changelog
- Updated `pyproject.toml`, `pdm.lock`
- Updated `ci.yaml` 