### PR TITLE
Fixing bug where repe algo is patching in ndarray instead of tensors

### DIFF
--- a/repepo/algorithms/repe.py
+++ b/repepo/algorithms/repe.py
@@ -147,7 +147,11 @@ class RepeReadingControl(Algorithm):
             ),
         )
         return RepeDirections(
-            activations=rep_reader.directions,
+            activations={
+                # rep reader retuns np.ndarray values, not tensors, so need to convert
+                key: torch.FloatTensor(val)
+                for key, val in rep_reader.directions.items()
+            },
             signs=rep_reader.direction_signs,
         )
 


### PR DESCRIPTION
This PR fixes a bug where we're patching ndarray elements into `ModelPatcher` instead of tensors. This is because it turns out that `RepReadingPipeline.get_directions()` retuns ndarray when it calculates PCA. This PR addresses this by explicitly converting to `FloatTensor` before attempting to patch.