### PR TITLE
limiting ICL max examples to avoid prepending entire dataset

### DIFF
--- a/repepo/algorithms/icl.py
+++ b/repepo/algorithms/icl.py
@@ -5,10 +5,18 @@ from repepo.core import Pipeline, Dataset
 
 
 class InContextLearning(Algorithm):
+    max_icl_examples: int
+
+    def __init__(self, max_icl_examples: int = 5):
+        super().__init__()
+        self.max_icl_examples = max_icl_examples
+
     def run(self, pipeline: Pipeline, dataset: Dataset) -> Pipeline:
         """Uses an in-context learning prefix to prompts"""
 
-        icl_completions = pipeline.formatter.apply_list(dataset)
+        icl_completions = pipeline.formatter.apply_list(
+            dataset[: self.max_icl_examples]
+        )
         new_prompter = FewShotPrompter(icl_completions)
 
         return replace(pipeline, prompter=new_prompter)

--- a/tests/algorithms/test_icl.py
+++ b/tests/algorithms/test_icl.py
@@ -23,3 +23,23 @@ def test_InContextLearning_run(model: GPTNeoXForCausalLM, tokenizer: Tokenizer) 
         Completion(prompt="Input:  London is in \nOutput: ", response="England"),
         Completion(prompt="Input:  Berlin is in \nOutput: ", response="Germany"),
     ]
+
+
+def test_InContextLearning_run_with_max_icl_examples(
+    model: GPTNeoXForCausalLM, tokenizer: Tokenizer
+) -> None:
+    pipeline = Pipeline(model, tokenizer)
+    algorithm = InContextLearning(max_icl_examples=2)
+    dataset = [
+        Example(instruction="", input="Paris is in", output="France"),
+        Example(instruction="", input="London is in", output="England"),
+        Example(instruction="", input="Berlin is in", output="Germany"),
+    ]
+
+    new_pipeline = algorithm.run(pipeline, dataset=dataset)
+
+    assert isinstance(new_pipeline.prompter, FewShotPrompter)
+    assert new_pipeline.prompter.few_shot_completions == [
+        Completion(prompt="Input:  Paris is in \nOutput: ", response="France"),
+        Completion(prompt="Input:  London is in \nOutput: ", response="England"),
+    ]


### PR DESCRIPTION
By default, the ICL algorithm will prepend the full dataset to every test example. This is obviously problematic when dealing with a real dataset. This PR adds a configuation param to the ICL algorithm to set a max number of samples to prepend.