### PR TITLE
Interleaving pos/neg prompts to match what the repe code expects

### DIFF
--- a/tests/algorithms/__snapshots__/test_repe.ambr
+++ b/tests/algorithms/__snapshots__/test_repe.ambr
@@ -1,14 +1,6 @@
 # serializer version: 1
-# name: test_RepeReadingControl_build_repe_training_data_and_labels
+# name: test_RepeReadingControl_build_repe_training_data_and_labels_picks_one_neg_by_default
   list([
-    '''
-      Consider the amount of truthfulness in the following answer.
-      
-      Input:  Paris is in 
-      Output:  France
-      
-      The amount of truthfulness in the answer is 
-    ''',
     '''
       Consider the amount of truthfulness in the following answer.
       
@@ -21,7 +13,7 @@
       Consider the amount of truthfulness in the following answer.
       
       Input:  Paris is in 
-      Output:  Italy
+      Output:  France
       
       The amount of truthfulness in the answer is 
     ''',
@@ -38,22 +30,6 @@
       
       Input:  1 + 1 = 
       Output:  11
-      
-      The amount of truthfulness in the answer is 
-    ''',
-    '''
-      Consider the amount of truthfulness in the following answer.
-      
-      Input:  1 + 1 = 
-      Output:  1234
-      
-      The amount of truthfulness in the answer is 
-    ''',
-    '''
-      Consider the amount of truthfulness in the following answer.
-      
-      Input:  1 + 1 = 
-      Output:  3.14
       
       The amount of truthfulness in the answer is 
     ''',

--- a/tests/algorithms/test_repe.py
+++ b/tests/algorithms/test_repe.py
@@ -6,7 +6,7 @@ from syrupy import SnapshotAssertion
 from transformers import GPTNeoXForCausalLM
 
 
-def test_RepeReadingControl_build_repe_training_data_and_labels(
+def test_RepeReadingControl_build_repe_training_data_and_labels_picks_one_neg_by_default(
     snapshot: SnapshotAssertion,
 ) -> None:
     dataset: Dataset = [
@@ -20,7 +20,7 @@ def test_RepeReadingControl_build_repe_training_data_and_labels(
             instruction="",
             input="1 + 1 =",
             output="2",
-            incorrect_outputs=["11", "1234", "3.14"],
+            incorrect_outputs=["11", "34", "3.14"],
         ),
     ]
     formatter = InputOutputFormatter()
@@ -29,9 +29,85 @@ def test_RepeReadingControl_build_repe_training_data_and_labels(
         dataset, formatter
     )
     # for some reason the training data isn't grouped, but labels are. This is how it is in the original code.
-    assert len(training_data) == 7
-    assert labels == [[1, 0, 0], [1, 0, 0, 0]]
+    assert len(training_data) == 4
+    # should pick the first incorrect output only by default
+    assert "Germany" in training_data[0]
+    assert "France" in training_data[1]
+    assert "2" in training_data[2]
+    assert "11" in training_data[3]
+    # should alternate between flipped and non-flipped labels
+    assert labels == [[0, 1], [1, 0]]
     assert training_data == snapshot
+
+
+def test_RepeReadingControl_build_repe_training_data_and_labels_with_random_incorrect() -> (
+    None
+):
+    dataset: Dataset = [
+        Example(
+            instruction="",
+            input="Paris is in",
+            output="France",
+            incorrect_outputs=["Germany", "Italy"],
+        ),
+        Example(
+            instruction="",
+            input="1 + 1 =",
+            output="2",
+            incorrect_outputs=["11", "34", "3.14"],
+        ),
+    ]
+    formatter = InputOutputFormatter()
+    algorithm = RepeReadingControl()
+    training_data, labels = algorithm._build_repe_training_data_and_labels(
+        dataset, formatter
+    )
+    # for some reason the training data isn't grouped, but labels are. This is how it is in the original code.
+    assert len(training_data) == 4
+    # should pick the a random incorrect output
+    assert "France" in training_data[1]
+    assert "2" in training_data[2]
+    # should alternate between flipped and non-flipped labels
+    assert labels == [[0, 1], [1, 0]]
+
+
+def test_RepeReadingControl_build_repe_training_data_and_labels_with_repeat_correct() -> (
+    None
+):
+    dataset: Dataset = [
+        Example(
+            instruction="",
+            input="Paris is in",
+            output="France",
+            incorrect_outputs=["Germany", "Italy"],
+        ),
+        Example(
+            instruction="",
+            input="1 + 1 =",
+            output="2",
+            incorrect_outputs=["11", "34", "3.14"],
+        ),
+    ]
+    formatter = InputOutputFormatter()
+    algorithm = RepeReadingControl(multi_answer_method="repeat_correct")
+    training_data, labels = algorithm._build_repe_training_data_and_labels(
+        dataset, formatter
+    )
+    # for some reason the training data isn't grouped, but labels are. This is how it is in the original code.
+    assert len(training_data) == 10
+    # the positive example should be repeated once for each incorrect output
+    assert "Germany" in training_data[0]
+    assert "France" in training_data[1]
+    assert "Italy" in training_data[2]
+    assert "France" in training_data[3]
+    assert "2" in training_data[4]
+    assert "11" in training_data[5]
+    assert "2" in training_data[6]
+    assert "34" in training_data[7]
+    assert "2" in training_data[8]
+    assert "3.14" in training_data[9]
+    # should alternate between flipped and non-flipped labels
+    assert labels == [[0, 1, 0, 1], [1, 0, 1, 0, 1, 0]]
 
 
 def test_RepeReadingControl_get_directions(
@@ -47,12 +123,14 @@ def test_RepeReadingControl_get_directions(
             incorrect_outputs=["Germany", "Italy"],
         ),
     ]
-    algorithm = RepeReadingControl()
+    algorithm = RepeReadingControl(multi_answer_method="repeat_correct")
     directions = algorithm._get_directions(pipeline, dataset)
     assert list(directions.activations.keys()) == [-1, -2, -3, -4, -5]
     assert list(directions.signs.keys()) == [-1, -2, -3, -4, -5]
     for act in directions.activations.values():
         assert act.shape == (1, 512)
+    for sign in directions.signs.values():
+        assert sign in [-1, 1]
 
 
 def test_RepeReadingControl_run(
@@ -61,19 +139,27 @@ def test_RepeReadingControl_run(
     tokenizer.pad_token_id = model.config.eos_token_id
     pipeline = Pipeline(model, tokenizer)
 
-    example = Example(
+    test_example = Example(
         instruction="",
         input="Paris is in",
         output="France",
         incorrect_outputs=["Germany", "Italy"],
     )
-    dataset: Dataset = [example]
+    dataset: Dataset = [
+        test_example,
+        Example(
+            instruction="",
+            input="1 + 1 =",
+            output="2",
+            incorrect_outputs=["11", "34", "3.14"],
+        ),
+    ]
 
-    original_outputs = pipeline.generate(example)
+    original_outputs = pipeline.generate(test_example)
 
     algorithm = RepeReadingControl()
     algorithm.run(pipeline, dataset)
-    new_outputs = pipeline.generate(example)
+    new_outputs = pipeline.generate(test_example)
 
     # TODO: find a better assertion that ensures this is actually doing what it should
     assert original_outputs != new_outputs


### PR DESCRIPTION
It appears that the original Repe reading vector code expects every positive example to be paired with its corresponding negative example next to it in a big list passed to the `find_directions()` method. This isn't documented anywhere, but means we can't simply pass prompts to the `find_directions()` method unimpeded. Also, the Repe PCA code doesn't properly reflect each difference vector across the origin, so it's important to have a balance of `<neg, pos>` and `<pos, neg>` pairs passed to the `find_directions()` method.

This PR addresses these issues by adding a `multi_answer_method` param to the `RepeReadingControl` algorithm. By default, this will select just the first incorrect answer to pair with the correct answer, but can also be set to `random_incorrect` to pick at random, or `repeat_correct` to instead duplicate the correct answer to pair with every incorrect answer. This PR also alternates the order of the `<neg, pos>` for each example to try to ensure a good balance of directions for PCA.