### PR TITLE
allow setting sweep datasets explicitly in experiments

### DIFF
--- a/repepo/experiments/sweep_llama2_7b_layers.py
+++ b/repepo/experiments/sweep_llama2_7b_layers.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import torch
 from repepo.core.format import LlamaChatFormatter
-from repepo.steering.sweep_layers import sweep_layers
+from repepo.steering.sweep_layers import SWEEP_DATASETS, sweep_layers
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from repepo.data.multiple_choice.make_mwe_xrisk import make_mwe as make_mwe_xrisk_caa
 from repepo.data.multiple_choice.make_mwe_persona import make_mwe_personas_caa
@@ -24,6 +24,7 @@ class LlamaSweepLayersConfig:
     multipliers: list[float] = field(
         default_factory=lambda: [-1.5, -1.0, -0.5, 0.5, 1.0, 1.5]
     )
+    datasets: list[str] = field(default_factory=lambda: SWEEP_DATASETS)
     force: bool = False
 
 
@@ -65,6 +66,8 @@ def sweep_llama_7b_layers(config: LlamaSweepLayersConfig):
         layers=range(32),
         train_split=config.train_split,
         test_split=config.test_split,
+        datasets=config.datasets,
+        multipliers=config.multipliers,
         formatter=LlamaChatFormatter(),
         save_progress_dir=output_dir,
     )

--- a/repepo/experiments/sweep_qwen_14b_layers.py
+++ b/repepo/experiments/sweep_qwen_14b_layers.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import torch
 from repepo.core.format import QwenChatFormatter
-from repepo.steering.sweep_layers import sweep_layers
+from repepo.steering.sweep_layers import SWEEP_DATASETS, sweep_layers
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from repepo.data.multiple_choice.make_mwe_xrisk import make_mwe as make_mwe_xrisk_caa
 from repepo.data.multiple_choice.make_mwe_persona import make_mwe_personas_caa
@@ -24,6 +24,7 @@ class QwenSweepLayersConfig:
     multipliers: list[float] = field(
         default_factory=lambda: [-1.5, -1.0, -0.5, 0.5, 1.0, 1.5]
     )
+    datasets: list[str] = field(default_factory=lambda: SWEEP_DATASETS)
     force: bool = False
 
 
@@ -65,6 +66,8 @@ def sweep_qwen_14b_layers(config: QwenSweepLayersConfig):
         layers=range(40),
         train_split=config.train_split,
         test_split=config.test_split,
+        multipliers=config.multipliers,
+        datasets=config.datasets,
         formatter=QwenChatFormatter(),
         save_progress_dir=output_dir,
     )


### PR DESCRIPTION
This PR allows us to override the `datasets` being used by sweep scripts when run from CLI. This is being done so that we can run a sweep only on low-performing datasets, to see if the results look any different to our original sweeps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to configure and utilize datasets in layer sweeping for Llama and Qwen models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->