### PR TITLE
adding 'ablate then add' operator support for evaluation

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -4,8 +4,8 @@
 [metadata]
 groups = ["default", "dev"]
 strategy = ["cross_platform"]
-lock_version = "4.4.1"
-content_hash = "sha256:b588ac7596b05edb578b0b11a9fcdd890b8201d3cca92eeecec851e6b6792018"
+lock_version = "4.4"
+content_hash = "sha256:7e4707586565c01d4fa1478726e25f1bfac6efc640d29e186f08ee189595d040"
 
 [[package]]
 name = "absl-py"
@@ -4219,7 +4219,7 @@ files = [
 
 [[package]]
 name = "steering-vectors"
-version = "0.10.2"
+version = "0.11.0"
 requires_python = "<4.0,>=3.10"
 summary = "Steering vectors for transformer language models in Pytorch / Huggingface"
 dependencies = [
@@ -4228,8 +4228,8 @@ dependencies = [
     "transformers<5.0.0,>=4.35.2",
 ]
 files = [
-    {file = "steering_vectors-0.10.2-py3-none-any.whl", hash = "sha256:32d052f22f33fc4d7f42fc39441cedc8f4cd70c89fb0f117db88bec6d9498254"},
-    {file = "steering_vectors-0.10.2.tar.gz", hash = "sha256:9924a228f06e80efd49b004b7e8769db343da38263c1e73429a1ad0e281f4618"},
+    {file = "steering_vectors-0.11.0-py3-none-any.whl", hash = "sha256:f677f4e2a4725d785a8afd60be3a930115677732888a24bf4713a9eab24f1f2a"},
+    {file = "steering_vectors-0.11.0.tar.gz", hash = "sha256:39e360d2fd244bfe0cedec2934fa9c8c8deb9fcfe647b11ee0e59cb43091c7af"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "termcolor>=2.4.0",
   "bitsandbytes==0.42.0",
   "nbdime>=4.0.1",
-  "steering-vectors>=0.10.0",
+  "steering-vectors>=0.11.0",
   "openai>=1.10.0",
   "arrr>=1.0.4",
   "spacy>=3.7.2",

--- a/repepo/experiments/persona_generalization.py
+++ b/repepo/experiments/persona_generalization.py
@@ -158,6 +158,7 @@ def run_persona_cross_steering_experiment(
     normalize_steering_magnitude_to_baseline: bool = True,
     show_progress: bool = True,
     patch_generation_tokens_only: bool = True,
+    patch_operator: Literal["add", "ablate_then_add"] = "add",
     skip_first_n_generation_tokens: int = 0,
     completion_template: str | None = None,
 ) -> PersonaCrossSteeringExperimentResult:
@@ -256,6 +257,7 @@ def run_persona_cross_steering_experiment(
         datasets=test_dataset_mapping,
         show_progress=show_progress,
         patch_generation_tokens_only=patch_generation_tokens_only,
+        patch_operator=patch_operator,
         skip_first_n_generation_tokens=skip_first_n_generation_tokens,
         completion_template=completion_template,
         multipliers=multipliers,
@@ -404,6 +406,7 @@ class PersonaGeneralizationExperimentConfig:
         "llama-chat-formatter"
     )
     patch_generation_tokens_only: bool = True
+    patch_operator: Literal["add", "ablate_then_add"] = "add"
     skip_first_n_generation_tokens: int = 0
     completion_template: str | None = None
     normalize_steering_magnitude_to_baseline: bool = True
@@ -483,6 +486,7 @@ def run_persona_generalization_experiment(
             layer=config.layer,
             normalize_steering_magnitude_to_baseline=config.normalize_steering_magnitude_to_baseline,
             patch_generation_tokens_only=config.patch_generation_tokens_only,
+            patch_operator=config.patch_operator,
             skip_first_n_generation_tokens=config.skip_first_n_generation_tokens,
             completion_template=config.completion_template,
             multipliers=config.multipliers,

--- a/repepo/steering/evaluate_cross_steering.py
+++ b/repepo/steering/evaluate_cross_steering.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Callable, NamedTuple
+from typing import Any, Callable, Literal, NamedTuple
 
 from steering_vectors import SteeringVector
 from tqdm import tqdm
@@ -46,6 +46,7 @@ def evaluate_cross_steering(
     multipliers: list[float],
     build_pipeline: Callable[[Model, Tokenizer, str], Any] | None = None,
     patch_generation_tokens_only: bool = True,
+    patch_operator: Literal["add", "ablate_then_add"] = "add",
     skip_first_n_generation_tokens: int = 0,
     completion_template: str | None = None,
     show_progress: bool = True,
@@ -87,6 +88,7 @@ def evaluate_cross_steering(
                 NormalizedPositiveProbabilityEvaluator(),
                 LogitDifferenceEvaluator(),
             ],
+            patch_operator=patch_operator,
             patch_generation_tokens_only=patch_generation_tokens_only,
             skip_first_n_generation_tokens=skip_first_n_generation_tokens,
             completion_template=completion_template,
@@ -106,6 +108,7 @@ def evaluate_cross_steering(
                     LogitDifferenceEvaluator(),
                 ],
                 patch_generation_tokens_only=patch_generation_tokens_only,
+                patch_operator=patch_operator,
                 skip_first_n_generation_tokens=skip_first_n_generation_tokens,
                 completion_template=completion_template,
                 show_progress=False,

--- a/repepo/steering/evaluate_steering_vector.py
+++ b/repepo/steering/evaluate_steering_vector.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Literal
 
 
 from repepo.core.types import Dataset
@@ -25,6 +26,7 @@ def evaluate_steering_vector(
     layers: list[int],
     multipliers: list[float],
     patch_generation_tokens_only: bool = True,
+    patch_operator: Literal["add", "ablate_then_add"] = "add",
     skip_first_n_generation_tokens: int = 0,
     system_prompt: str | None = None,
     completion_template: str | None = None,
@@ -46,6 +48,7 @@ def evaluate_steering_vector(
         patch_generation_tokens_only=patch_generation_tokens_only,
         skip_first_n_generation_tokens=skip_first_n_generation_tokens,
         layer_config=guess_and_enhance_layer_config(pipeline.model),
+        patch_operator=patch_operator,
     )
     pipeline.hooks.append(steering_hook)
 

--- a/repepo/steering/run_experiment.py
+++ b/repepo/steering/run_experiment.py
@@ -192,6 +192,7 @@ def evaluate_steering_vector_from_config(
             layers=[config.layer],
             multipliers=[config.multiplier],
             patch_generation_tokens_only=config.patch_generation_tokens_only,
+            patch_operator=config.patch_operator,
             skip_first_n_generation_tokens=config.skip_first_n_generation_tokens,
             logger=logger,
             slim_results=config.slim_eval,

--- a/repepo/steering/utils/helpers.py
+++ b/repepo/steering/utils/helpers.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+from typing import Literal
 import torch
 import pandas as pd
 import gc
@@ -116,6 +117,7 @@ class SteeringConfig:
     patch_generation_tokens_only: bool = True
     skip_first_n_generation_tokens: int = 0
     slim_eval: bool = True
+    patch_operator: Literal["add", "ablate_then_add"] = "add"
 
     @property
     def train_hash(self):

--- a/scripts/persona_generalization_ablate.qsub.sh
+++ b/scripts/persona_generalization_ablate.qsub.sh
@@ -1,11 +1,11 @@
-#$ -N persona_generalization_qwen            # Specify the job name
+#$ -N persona_generalization_ablate     # Specify the job name
 #$ -l h_rt=72:00:00
 #$ -l h_vmem=64G           # Request 64GB of memory per job
 #$ -l gpu=1               # Request 1 GPU
 #$ -ac allow=L        # Specify the type of GPU
 #$ -S /bin/bash
 #$ -j y
-#$ -t 0-40
+#$ -t 0-10
 
 nvidia-smi
 umask 0077
@@ -21,8 +21,6 @@ source ${HOME}/Scratch/gpu-pyenv/bin/activate
 
 # Run the script
 PYTHON_PATH=. python3 -m repepo.experiments.persona_generalization \
-    --layer 21 \
-    --model_name Qwen/Qwen1.5-14B-Chat \
-    --formatter_name qwen-chat-formatter \
-    --output_dir ${HOME}/Scratch/persona_generalization_qwen \
+    --output_dir experiments/persona_generalization_ablate \
+    --patch_operator ablate_then_add \
     --sge_task_id $SGE_TASK_ID

--- a/scripts/persona_generalization_qwen_ablate.qsub.sh
+++ b/scripts/persona_generalization_qwen_ablate.qsub.sh
@@ -1,11 +1,11 @@
-#$ -N persona_generalization_qwen            # Specify the job name
+#$ -N persona_generalization_qwen_ablate            # Specify the job name
 #$ -l h_rt=72:00:00
 #$ -l h_vmem=64G           # Request 64GB of memory per job
 #$ -l gpu=1               # Request 1 GPU
 #$ -ac allow=L        # Specify the type of GPU
 #$ -S /bin/bash
 #$ -j y
-#$ -t 0-40
+#$ -t 0-10
 
 nvidia-smi
 umask 0077
@@ -24,5 +24,6 @@ PYTHON_PATH=. python3 -m repepo.experiments.persona_generalization \
     --layer 21 \
     --model_name Qwen/Qwen1.5-14B-Chat \
     --formatter_name qwen-chat-formatter \
-    --output_dir ${HOME}/Scratch/persona_generalization_qwen \
+    --output_dir ${HOME}/Scratch/persona_generalization_qwen_ablate \
+    --patch_operator ablate_then_add \
     --sge_task_id $SGE_TASK_ID


### PR DESCRIPTION
This should allow us to evaluate how steering vectors perform when applied using ablation the addition, instead of just addition only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `patch_operator` parameter for various experiment scripts and functions. This allows users to specify the type of patch operation for experiments.

- **Bug Fixes**
  - Modified the persona generalization script to update task range settings and streamline code updates.

- **Chores**
  - Updated the version of the `steering-vectors` package to ensure compatibility with recent changes.
  - Added new scripts for persona generalization ablation experiments to facilitate specific experiment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->