### PR TITLE
fixing ablate_then_add operator with 0 magnitude steering

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform"]
 lock_version = "4.4"
-content_hash = "sha256:7e4707586565c01d4fa1478726e25f1bfac6efc640d29e186f08ee189595d040"
+content_hash = "sha256:348a9cde71babbe6fa5e5b61b077aa7bb1c3357f4dd015011da588c7fc5e7dd1"
 
 [[package]]
 name = "absl-py"
@@ -4219,7 +4219,7 @@ files = [
 
 [[package]]
 name = "steering-vectors"
-version = "0.11.0"
+version = "0.12.1"
 requires_python = "<4.0,>=3.10"
 summary = "Steering vectors for transformer language models in Pytorch / Huggingface"
 dependencies = [
@@ -4228,8 +4228,8 @@ dependencies = [
     "transformers<5.0.0,>=4.35.2",
 ]
 files = [
-    {file = "steering_vectors-0.11.0-py3-none-any.whl", hash = "sha256:f677f4e2a4725d785a8afd60be3a930115677732888a24bf4713a9eab24f1f2a"},
-    {file = "steering_vectors-0.11.0.tar.gz", hash = "sha256:39e360d2fd244bfe0cedec2934fa9c8c8deb9fcfe647b11ee0e59cb43091c7af"},
+    {file = "steering_vectors-0.12.1-py3-none-any.whl", hash = "sha256:0f8e7bf764e25b522d07efa3973ab25e3aecf1f22d41cc6c053e7c89eb39a62a"},
+    {file = "steering_vectors-0.12.1.tar.gz", hash = "sha256:a0c359cc2f35decf9bfb02d47b3854bf96ab52710247a8d4e099c51fc6c614b6"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "termcolor>=2.4.0",
   "bitsandbytes==0.42.0",
   "nbdime>=4.0.1",
-  "steering-vectors>=0.11.0",
+  "steering-vectors>=0.12.1",
   "openai>=1.10.0",
   "arrr>=1.0.4",
   "spacy>=3.7.2",

--- a/repepo/core/hook.py
+++ b/repepo/core/hook.py
@@ -42,17 +42,19 @@ class SteeringHook(PipelineHook):
                     context.full_prompt,
                 )
                 min_token_index = gen_start_index + self.skip_first_n_generation_tokens
-            handle = self.steering_vector.patch_activations(
-                model=context.pipeline.model,
-                layer_config=self.layer_config,
-                multiplier=self.direction_multiplier,
-                min_token_index=min_token_index,
-                operator=(
-                    ablation_then_addition_operator()
-                    if self.patch_operator == "ablate_then_add"
-                    else None
-                ),
-            )
+            # multiplier 0 is equivalent to no steering, so just skip patching in that case
+            if self.direction_multiplier != 0:
+                handle = self.steering_vector.patch_activations(
+                    model=context.pipeline.model,
+                    layer_config=self.layer_config,
+                    multiplier=self.direction_multiplier,
+                    min_token_index=min_token_index,
+                    operator=(
+                        ablation_then_addition_operator()
+                        if self.patch_operator == "ablate_then_add"
+                        else None
+                    ),
+                )
             yield
         finally:
             if handle is not None:

--- a/repepo/steering/evaluate_cross_steering.py
+++ b/repepo/steering/evaluate_cross_steering.py
@@ -83,7 +83,7 @@ def evaluate_cross_steering(
             steering_vector=first_sv,
             dataset=dataset,
             layers=[layer],
-            multipliers=[0.0],
+            multipliers=[0],
             evaluators=[
                 NormalizedPositiveProbabilityEvaluator(),
                 LogitDifferenceEvaluator(),

--- a/tests/experiments/test_persona_generalization.py
+++ b/tests/experiments/test_persona_generalization.py
@@ -11,6 +11,7 @@ from repepo.experiments.persona_generalization import (
     PersonaCrossSteeringExperimentResult,
     base_dataset_position,
     persona_pipeline,
+    run_persona_cross_steering_experiment,
 )
 from repepo.steering.evaluate_cross_steering import CrossSteeringResult
 
@@ -200,3 +201,21 @@ def test_base_dataset_position_is_near_zero_if_base_is_near_neg(
     )
     assert base_dataset_position(results, dist_metric=dist_metric) < 0.2
     assert base_dataset_position(results, dist_metric=dist_metric) > 0.0
+
+
+def test_run_persona_cross_steering_experiment(
+    model: GPTNeoXForCausalLM,
+    tokenizer: Tokenizer,
+) -> None:
+    result = run_persona_cross_steering_experiment(
+        model,
+        tokenizer,
+        train_split="0:4",
+        test_split="4:8",
+        dataset_name="myopic-reward",
+        formatter_name="llama-chat-formatter",
+        layer=1,
+        patch_operator="ablate_then_add",
+        multipliers=[-1.0, 1.0],
+    )
+    assert result is not None


### PR DESCRIPTION
When doing ablation, zero-magnitude steering vectors cause NaN issues. This PR skips steering if the magnitude is 0. This should be a minor performance boost as well for the 0 magnitude case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the `steering-vectors` dependency to version `0.12.1`, resolving compatibility issues.

- **Tests**
  - Added a new test for `run_persona_cross_steering_experiment`, ensuring functionality with specific parameters.

- **Refactor**
  - Improved handling logic by skipping patching when `direction_multiplier` is 0.
  - Simplified multipliers list in `evaluate_cross_steering` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->